### PR TITLE
[Bug] ダウンロード機能の修正

### DIFF
--- a/backend/src/usecase/downloads/zip_create.py
+++ b/backend/src/usecase/downloads/zip_create.py
@@ -14,8 +14,6 @@ def create_zip_buffer():
         files = glob.glob(os.path.join(tmp_dir_path, "**"))
         for file in files:
             if os.path.isfile(file):
-                # Use the filename only as the arcname to avoid path issues
-                arcname = os.path.basename(file)
-                zipf.write(file, arcname)
+                zipf.write(file, arcname=os.path.basename(file))
     zip_buffer.seek(0)
     return zip_buffer


### PR DESCRIPTION
Issue #49 の修正

- ZIPファイルが壊れる問題を修正
- `zip_create.py` の `create_zip_buffer` 関数で、ファイルをZIPに追加する際のパス指定を修正
- `os.path.relpath(file, TMP_DIR_PATH)` の代わりに `os.path.basename(file)` を使用して、ファイル名のみをZIPに含めるように変更