### PR TITLE
Fix concurrent download issue by using unique temporary directories

### DIFF
--- a/backend/src/handler/ee_daily_zip_handler.py
+++ b/backend/src/handler/ee_daily_zip_handler.py
@@ -1,4 +1,5 @@
 import base64
+import os
 from datetime import timedelta
 
 from fastapi import Depends, Query
@@ -11,6 +12,7 @@ from src.usecase.downloads.iaga_meta_data import get_meta_data
 from src.usecase.downloads.iaga_save_file import save_iaga_format
 from src.usecase.downloads.remove_files import remove_files
 from src.usecase.downloads.zip_create import create_zip_buffer
+from src.usecase.downloads.tmp_path import get_unique_tmp_dir
 from src.usecase.ee_index.calc_edst import Edst
 from src.usecase.ee_index.calc_er import Er
 from src.usecase.ee_index.calc_euel import Euel
@@ -79,8 +81,19 @@ def handle_get_daily_ee_index_zip_file(
         "ER": er_values,
         "EUEL": euel_values,
     }
-    save_iaga_format(meta_data, data, generate_parent_abs_path("/tmp/iaga_format.txt"))
-    zip_buffer = create_zip_buffer()
-    zip_base64 = base64.b64encode(zip_buffer.getvalue()).decode("utf-8")
-    remove_files()
-    return JSONResponse(content={"file": zip_base64})
+    # Create a unique temporary directory for this request
+    tmp_dir = get_unique_tmp_dir()
+    iaga_file_path = os.path.join(tmp_dir, "iaga_format.txt")
+    
+    try:
+        # Save the file to the unique temporary directory
+        save_iaga_format(meta_data, data, iaga_file_path)
+        
+        # Create zip file from the unique temporary directory
+        zip_buffer = create_zip_buffer(tmp_dir)
+        zip_base64 = base64.b64encode(zip_buffer.getvalue()).decode("utf-8")
+        
+        return JSONResponse(content={"file": zip_base64})
+    finally:
+        # Always clean up the temporary directory, even if an error occurs
+        remove_files(tmp_dir)

--- a/backend/src/usecase/downloads/remove_files.py
+++ b/backend/src/usecase/downloads/remove_files.py
@@ -1,11 +1,13 @@
 import os
 import shutil
 
-from src.usecase.downloads.tmp_path import TMP_DIR_PATH
-from src.utils.path import generate_parent_abs_path
 
-
-def remove_files():
-    tmp_dir_path = generate_parent_abs_path(TMP_DIR_PATH)
-    shutil.rmtree(tmp_dir_path)
-    os.mkdir(tmp_dir_path)
+def remove_files(tmp_dir_path):
+    """
+    Remove the temporary directory and all its contents.
+    
+    Args:
+        tmp_dir_path: Path to the temporary directory to remove
+    """
+    if os.path.exists(tmp_dir_path):
+        shutil.rmtree(tmp_dir_path)

--- a/backend/src/usecase/downloads/tmp_path.py
+++ b/backend/src/usecase/downloads/tmp_path.py
@@ -1,1 +1,18 @@
-TMP_DIR_PATH = "/tmp"
+import os
+import uuid
+
+TMP_BASE_DIR = "/tmp"
+
+def get_unique_tmp_dir():
+    """
+    Generate a unique temporary directory path for each download request.
+    This prevents race conditions when multiple users download files simultaneously.
+    """
+    unique_id = str(uuid.uuid4())
+    tmp_dir = os.path.join(TMP_BASE_DIR, f"magdas_download_{unique_id}")
+    
+    # Create the directory if it doesn't exist
+    if not os.path.exists(tmp_dir):
+        os.makedirs(tmp_dir)
+        
+    return tmp_dir

--- a/backend/src/usecase/downloads/zip_create.py
+++ b/backend/src/usecase/downloads/zip_create.py
@@ -3,14 +3,19 @@ import io
 import os
 from zipfile import ZipFile
 
-from src.usecase.downloads.tmp_path import TMP_DIR_PATH
-from src.utils.path import generate_parent_abs_path
 
-
-def create_zip_buffer():
+def create_zip_buffer(tmp_dir_path):
+    """
+    Create a zip file containing all files in the specified temporary directory.
+    
+    Args:
+        tmp_dir_path: Path to the temporary directory containing files to zip
+        
+    Returns:
+        BytesIO: A buffer containing the zip file
+    """
     zip_buffer = io.BytesIO()
     with ZipFile(zip_buffer, "w") as zipf:
-        tmp_dir_path = generate_parent_abs_path(TMP_DIR_PATH)
         files = glob.glob(os.path.join(tmp_dir_path, "**"))
         for file in files:
             if os.path.isfile(file):


### PR DESCRIPTION
## 概要

複数のユーザーが同時にダウンロード機能を使用した際に発生する競合状態を修正しました。

## 変更内容

- 一時ディレクトリを共有する代わりに、各ダウンロードリクエストごとに一意の一時ディレクトリを生成するように変更
- `tmp_path.py`に`get_unique_tmp_dir()`関数を追加して、UUIDベースの一意のディレクトリを生成
- `remove_files.py`を更新して、特定のディレクトリパスを受け取るように変更
- `zip_create.py`を更新して、指定された一時ディレクトリで動作するように変更
- `ee_zip_handler.py`と`ee_daily_zip_handler.py`を更新して、新しい関数を使用するように変更
- エラーが発生した場合でも一時ディレクトリが確実にクリーンアップされるように、try/finallyパターンを実装

これらの変更により、複数のユーザーが同時にダウンロード機能を使用しても、それぞれが独立した一時ディレクトリを使用するため、競合状態が発生しなくなります。

Fixes #57