### PR TITLE
[frontend] 開始期間と終了期間の入力について

### DIFF
--- a/frontend/src/pages/download/_components/PeriodSelection.tsx
+++ b/frontend/src/pages/download/_components/PeriodSelection.tsx
@@ -12,23 +12,34 @@ interface FormData {
 
 // 日付を比較する関数
 const compareDates = (date1: DateValue, date2: DateValue): number => {
-  if (!date1.year || !date1.month || !date1.day || !date2.year || !date2.month || !date2.day) {
+  if (
+    !date1.year ||
+    !date1.month ||
+    !date1.day ||
+    !date2.year ||
+    !date2.month ||
+    !date2.day
+  ) {
     return 0;
   }
-  
+
   const d1 = new Date(
     parseInt(date1.year),
     parseInt(date1.month) - 1,
     parseInt(date1.day)
   );
-  
+
   const d2 = new Date(
     parseInt(date2.year),
     parseInt(date2.month) - 1,
     parseInt(date2.day)
   );
-  
+
   return d1.getTime() - d2.getTime();
+};
+
+const isValidDate = (date?: DateValue) => {
+  return !!(date?.year && date.month && date.day);
 };
 
 const PeriodSelectionForm: React.FC = () => {
@@ -49,27 +60,21 @@ const PeriodSelectionForm: React.FC = () => {
   const startDate = watch("startDate");
   const endDate = watch("endDate");
 
-  // 開始日が変更されたときの処理
+  // 開始日を選択したとき、終了日が開始日より前の日付にならないようにする
   useEffect(() => {
-    if (startDate?.year && startDate?.month && startDate?.day && 
-        endDate?.year && endDate?.month && endDate?.day) {
-      // 開始日が終了日より未来の場合、終了日を開始日と同じにする
-      if (compareDates(startDate, endDate) > 0) {
-        setValue("endDate", { ...startDate });
-      }
+    if (!isValidDate(startDate) || !isValidDate(endDate)) return;
+    if (compareDates(startDate, endDate) > 0) {
+      setValue("endDate", { ...startDate });
     }
-  }, [startDate, endDate, setValue]);
+  }, [startDate, setValue]);
 
-  // 終了日が変更されたときの処理
+  // 終了日を選択したとき、開始日が終了日より後の日付にならないようにする
   useEffect(() => {
-    if (startDate?.year && startDate?.month && startDate?.day && 
-        endDate?.year && endDate?.month && endDate?.day) {
-      // 終了日が開始日より過去の場合、開始日を終了日と同じにする
-      if (compareDates(startDate, endDate) > 0) {
-        setValue("startDate", { ...endDate });
-      }
+    if (!isValidDate(startDate) || !isValidDate(endDate)) return;
+    if (compareDates(startDate, endDate) > 0) {
+      setValue("startDate", { ...endDate });
     }
-  }, [endDate, startDate, setValue]);
+  }, [endDate, setValue]);
 
   const onSubmit = async (data: FormData) => {
     const props = {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,20 +7,4 @@ export default defineConfig({
     alias: [{ find: "@", replacement: "/src" }],
   },
   plugins: [react()],
-  server: {
-    host: "0.0.0.0",
-    port: 12000,
-    strictPort: true,
-    cors: true,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-    },
-    hmr: {
-      clientPort: 443,
-    },
-    watch: {
-      usePolling: true,
-    },
-    allowedHosts: "all",
-  },
 });


### PR DESCRIPTION
## 変更内容

- 開始日入力時に終了日よりも未来になったときに、入力した開始日と終了日を同じにする
- 終了日入力時に開始日よりも過去になったときに、入力した終了日と開始日を同じにする

## 実装方法

1. 日付を比較する関数 `compareDates` を追加
2. 開始日が変更されたときに終了日と比較し、開始日が未来の場合は終了日を開始日に合わせる
3. 終了日が変更されたときに開始日と比較し、終了日が過去の場合は開始日を終了日に合わせる

Issue #65 の対応